### PR TITLE
feat: s config rename

### DIFF
--- a/bin/s-config-rename
+++ b/bin/s-config-rename
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../lib/config/rename');

--- a/docs/en/command/config.md
+++ b/docs/en/command/config.md
@@ -19,6 +19,9 @@ The `config` commands are used to perform operations on keys. For example, you c
 - [config delete command](#config-delete-command)
     - [Parameter description](#Parameter-description-2)
     - [Example](#Example-2)
+- [config rename command](#config-rename-command)
+  - [Parameter description](#Parameter-description-3)
+  - [Example](#Example-3)
 - [Precautions](#Precautions)
     - [Configure keys by using environment variables](#Configure-keys-by-using-environment-variables)
     - [Configure the order in which keys are used](#Configure-the-order-in-which-keys-are-used)
@@ -46,7 +49,8 @@ Commands:
 In the preceding command, the following subcommands are included: 
 - [add: specifies to add configurations of keys.](#config-add-command)
 - [get: specifies to view configurations of keys.](#config-get-command)
-- [delete: specifies to delete configurations of keys.](#config-delete-command) 
+- [delete: specifies to delete configurations of keys.](#config-delete-command)
+- [delete: specifies to rename configurations of keys.](#config-rename-command)
 
 
 ## config add command
@@ -273,6 +277,44 @@ If you want to delete a configured key, run the `config delete` command. For exa
 ```shell script
 $ s config delete -a test
 Key [test] has been successfully removed
+```
+
+## config rename command
+
+You can run the s `config rename` command to rename the information about a configured account.
+
+You can run the `-h/--help` command to obtain the following help information about configurations
+
+```shell script
+$ s config rename -h
+
+Usage: s config rename <sourceAliasName> <targetAliasName>
+
+You can rename an account.
+
+     Example:
+        $ s config rename sourceAliasName targetAliasName
+
+
+Options:
+  -h,--help                 Display help for command
+```
+
+### Parameter description
+
+| Parameter | Abbreviation | Required | Description              |
+|-----|--------------|-----|--------------------------|
+| sourceAliasName |              | Yes | Source alias of the key. |
+| targetAliasName |              | Yes | Target alias of the key. |
+
+
+### Example
+
+If you want to rename a configured key, run the `config rename` command. For example, if you want to rename a configured key whose alias is `test` to `test2`, run the following command:
+
+```shell script
+$ s config rename test test2  
+Key [test] has been successfully rename to [test2].
 ```
 
 ## Precautions

--- a/docs/zh/command/config.md
+++ b/docs/zh/command/config.md
@@ -19,6 +19,9 @@ category: '命令'
 - [config delete 命令](#config-delete-命令)
     - [参数解析](#参数解析-2)
     - [操作案例](#操作案例-2)
+- [config rename 命令](#config-rename-命令)
+    - [参数解析](#参数解析-3)
+    - [操作案例](#操作案例-3)
 - [注意事项](#注意事项)
     - [通过环境变量设置密钥](#通过环境变量设置密钥)
     - [关于配置密钥的使用顺序](#关于配置密钥的使用顺序)
@@ -41,12 +44,14 @@ Commands:
   add         ➕ Add an account
   get         ✔️ Get accounts
   delete      ✖️ Delete an account
+  rename      >️ Rename an account
 ```
 
-在该命令中，包括了三个子命令：
+在该命令中，包括了四个子命令：
 - [add：添加密钥配置](#config-add-命令)
 - [get：查看密钥配置](#config-get-命令)
 - [delete：删除密钥配置](#config-delete-命令)
+- [rename：重命名密钥配置](#config-rename-命令)
 
 
 ## config add 命令
@@ -267,6 +272,43 @@ Options:
 ```shell script
 $ s config delete -a test
 Key [test] has been successfully removed
+```
+
+## config rename 命令
+
+通过`config rename`命令，您可以更改配置过的密钥信息名称。
+
+通过`-h/--help`可以查看到配置帮助：
+
+```shell script
+$ s config rename -h
+
+Usage: s config rename <sourceAliasName> <targetAliasName>
+
+You can rename an account.
+
+     Example:
+        $ s config rename sourceAliasName targetAliasName
+
+
+Options:
+  -h,--help                 Display help for command
+```
+
+### 参数解析
+
+| 参数全称 | 参数缩写 | 是否必填 | 参数含义     |
+|-----|------|-----|----------|
+| sourceAliasName |      | 必填 | 原始密钥的别名  |
+| targetAliasName |      | 必填 | 变更后密钥的别名 |
+
+### 操作案例
+
+如果想要变更某个已经配置的密钥的别名，可以通过`config rename`进行删除，例如，想要删除别名为`test`的密钥信息别名为`test2`，就可以执行：
+
+```shell script
+$ s config rename test test2  
+Key [test] has been successfully rename to [test2].
 ```
 
 ## 注意事项

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,6 +19,7 @@ program
   .command('add', `${emoji(colors.bold('+'))}` + 'Add an account')
   .command('get', `${emoji(colors.bold('√'))}` + 'Get accounts')
   .command('delete', `${emoji(colors.bold('×'))}` + 'Delete an account')
+  .command('rename', `${emoji(colors.bold('>'))}` + 'Rename an account')
   .description(description)
   .addHelpCommand(false)
   .parse(process.argv);

--- a/src/config/rename/index.ts
+++ b/src/config/rename/index.ts
@@ -1,0 +1,77 @@
+/** @format */
+
+import path from 'path';
+import fs from 'fs';
+import program from '@serverless-devs/commander';
+import { logger } from '../../utils';
+import { HandleError, HumanError } from '../../error';
+import { emoji } from '../../utils';
+import core from '../../utils/core';
+const { colors, jsyaml: yaml, getRootHome, getYamlContent } = core;
+
+const description = `You can rename an account.
+  
+  Example:
+    $ s config rename sourceAliasName targetAliasName
+    
+${emoji('📖')} Document: ${colors.underline(
+  'https://github.com/Serverless-Devs/Serverless-Devs/tree/master/docs/zh/command/config.md',
+)}`;
+
+function notFound({ source, accessFileInfo }: { source: string; accessFileInfo?: any }) {
+  const errorMessage = accessFileInfo
+    ? `Unable to get key information with alias ${source}, You have configured these keys: [${String(
+        Object.keys(accessFileInfo),
+      )}].`
+    : `Unable to get key information with alias ${source}`;
+  new HumanError({
+    errorMessage,
+    tips: `You can use [s config add -h] to view configuration help, Serverless Devs' config document can refer to：${colors.underline(
+      'https://github.com/Serverless-Devs/Serverless-Devs/blob/master/docs/zh/command/config.md',
+    )}`,
+  });
+}
+
+function exists({ target, accessFileInfo }: { target: string; accessFileInfo?: any }) {
+  const errorMessage = `${target} had exists in ${accessFileInfo}`;
+  new HumanError({
+    errorMessage,
+    tips: `You can use [s config get] list accounts`,
+  });
+}
+
+(async () => {
+  program
+    .name('s config rename')
+    .usage('<sourceAliasName> <targetAliasName>')
+    .helpOption('-h, --help', 'Display help for command')
+    .description(description)
+    .addHelpCommand(false)
+    .parse(process.argv);
+
+  if (program.args.length !== 2) {
+    program.help();
+  }
+
+  const source = program.args[0];
+  const target = program.args[1];
+
+  const filePath = path.join(getRootHome(), 'access.yaml');
+  const accessFileInfo = await getYamlContent(filePath);
+  if (accessFileInfo) {
+    if (accessFileInfo[target]) {
+      exists({ target, accessFileInfo });
+    } else if (accessFileInfo[source]) {
+      accessFileInfo[target] = accessFileInfo[source];
+      delete accessFileInfo[source];
+      fs.writeFileSync(filePath, yaml.dump(accessFileInfo));
+      logger.success(`Key [${source}] has been successfully rename to [${target}].`);
+    } else {
+      notFound({ source, accessFileInfo });
+    }
+  } else {
+    notFound({ source, accessFileInfo });
+  }
+})().catch(async error => {
+  await HandleError(error);
+});


### PR DESCRIPTION
## Others

Please forgive my poor English, I am using serverless devs.

I use my own laptop development in the company, and I need to manage many accounts, including company-dev-account / company-testing-account / my own learning account.

Often forget to enter their alias names. there is no way to modify. deleting and adding will be more steps. I minimally modified the code and completed this feature.

```shell
s config rename --FromAliasName aliasName1 --ToAliasName aliasName2
```

<img width="794" alt="001" src="https://user-images.githubusercontent.com/20847533/179469654-b237ff7e-02ae-4547-b1d2-991652953281.png">

What makes me confused is that I don't know why I can't parse the second command short parameter, Please help me code review, I really want to fix it.


<img width="602" alt="002" src="https://user-images.githubusercontent.com/20847533/179469982-e55704f3-6ad9-4d4c-8387-a5daf66c71bb.png">


<img width="599" alt="003" src="https://user-images.githubusercontent.com/20847533/179469994-f5e2a676-029e-4d27-b042-5d5f3d44b6ab.png">




