### PR TITLE
fix: jest js-jest 与 typescript 版本不兼容问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "husky": "^4.2.3",
     "inquirer": "8.2.0",
     "inquirer-autocomplete-prompt": "^1.3.0",
-    "jest": "^27.4.7",
+    "jest": "^29.5.0",
     "latest-version": "^5.1.0",
     "lint-staged": "^10.0.8",
     "open": "^8.4.0",
@@ -76,7 +76,7 @@
     "prettier": "^2.2.1",
     "semver": "^7.3.5",
     "semver-diff": "^3.1.1",
-    "ts-jest": "^27.1.3",
+    "ts-jest": "^29.1.0",
     "ts-node": "^9.1.1",
     "typescript": "^5.0.4"
   },


### PR DESCRIPTION
## Fix bugs

**Bug detail**
> jest 24.x 要求 typescript 版本 <5，选择 jest 29.x可支持到 typescript ^5.04

**Pull request tasks**
- [ ] Add test cases for the changes
- [x] Passed the CI test