### PR TITLE
chore(deps): update engine and load-component to newer beta versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       "devDependencies": {
         "@serverless-devs/core": "^0.1.67-beta.1",
         "@serverless-devs/credential": "^0.0.10",
-        "@serverless-devs/engine": "^0.1.6-beta.20",
+        "@serverless-devs/engine": "^0.1.6-beta.21",
         "@serverless-devs/load-application": "^0.0.16-beta.3",
-        "@serverless-devs/load-component": "^0.0.10-beta.6",
+        "@serverless-devs/load-component": "^0.0.10-beta.7",
         "@serverless-devs/logger": "^0.0.6",
         "@serverless-devs/parse-spec": "^0.0.30-beta.3",
         "@serverless-devs/registry": "^0.0.12-beta.7",
@@ -2600,16 +2600,16 @@
       "dev": true
     },
     "node_modules/@serverless-devs/engine": {
-      "version": "0.1.6-beta.20",
-      "resolved": "https://registry.npmjs.org/@serverless-devs/engine/-/engine-0.1.6-beta.20.tgz",
-      "integrity": "sha512-bxskIW7H2vkuyEydZBKzgxEDaMbEkl9OTQA7tX5HgMKZ7p29YpU2TFBgKazqpG4KFBeZYyKS3m1wUwZIQoQaKw==",
+      "version": "0.1.6-beta.21",
+      "resolved": "https://registry.npmjs.org/@serverless-devs/engine/-/engine-0.1.6-beta.21.tgz",
+      "integrity": "sha512-UR5LbLsYQYf6SjsvskSCCLfftKLn6Xi77F7LR+BRrARg28dl07XBdEl6wZwcDIuWZxVR5PkLcA0KPnD6V6+NTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@serverless-cd/debug": "^4.3.4",
         "@serverless-devs/credential": "^0.0.10",
         "@serverless-devs/load-application": "^0.0.16-beta.3",
-        "@serverless-devs/load-component": "^0.0.10-beta.6",
+        "@serverless-devs/load-component": "^0.0.10-beta.7",
         "@serverless-devs/logger": "^0.0.6",
         "@serverless-devs/parse-spec": "^0.0.30-beta.3",
         "@serverless-devs/secret": "^0.0.3",
@@ -2893,9 +2893,9 @@
       }
     },
     "node_modules/@serverless-devs/load-component": {
-      "version": "0.0.10-beta.6",
-      "resolved": "https://registry.npmjs.org/@serverless-devs/load-component/-/load-component-0.0.10-beta.6.tgz",
-      "integrity": "sha512-8VKH9UOTo1w7aQTL2MzRiLFp4IJAI3hwl6leiG3BJ+tbfMhDvbq4YhSTkGpFsIC26arASl9CLCd0Jp6zYN9Y8A==",
+      "version": "0.0.10-beta.7",
+      "resolved": "https://registry.npmjs.org/@serverless-devs/load-component/-/load-component-0.0.10-beta.7.tgz",
+      "integrity": "sha512-rKwnmycw6On94g02q36JNHAC4VJ3DcDhNj2vjGdSwVQ+20iHWXiHGa5zOYQpvfn9W3+v5HNKpff+4It/xmKmGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14811,15 +14811,15 @@
       }
     },
     "@serverless-devs/engine": {
-      "version": "0.1.6-beta.20",
-      "resolved": "https://registry.npmjs.org/@serverless-devs/engine/-/engine-0.1.6-beta.20.tgz",
-      "integrity": "sha512-bxskIW7H2vkuyEydZBKzgxEDaMbEkl9OTQA7tX5HgMKZ7p29YpU2TFBgKazqpG4KFBeZYyKS3m1wUwZIQoQaKw==",
+      "version": "0.1.6-beta.21",
+      "resolved": "https://registry.npmjs.org/@serverless-devs/engine/-/engine-0.1.6-beta.21.tgz",
+      "integrity": "sha512-UR5LbLsYQYf6SjsvskSCCLfftKLn6Xi77F7LR+BRrARg28dl07XBdEl6wZwcDIuWZxVR5PkLcA0KPnD6V6+NTg==",
       "dev": true,
       "requires": {
         "@serverless-cd/debug": "^4.3.4",
         "@serverless-devs/credential": "^0.0.10",
         "@serverless-devs/load-application": "^0.0.16-beta.3",
-        "@serverless-devs/load-component": "^0.0.10-beta.6",
+        "@serverless-devs/load-component": "^0.0.10-beta.7",
         "@serverless-devs/logger": "^0.0.6",
         "@serverless-devs/parse-spec": "^0.0.30-beta.3",
         "@serverless-devs/secret": "^0.0.3",
@@ -15036,9 +15036,9 @@
       }
     },
     "@serverless-devs/load-component": {
-      "version": "0.0.10-beta.6",
-      "resolved": "https://registry.npmjs.org/@serverless-devs/load-component/-/load-component-0.0.10-beta.6.tgz",
-      "integrity": "sha512-8VKH9UOTo1w7aQTL2MzRiLFp4IJAI3hwl6leiG3BJ+tbfMhDvbq4YhSTkGpFsIC26arASl9CLCd0Jp6zYN9Y8A==",
+      "version": "0.0.10-beta.7",
+      "resolved": "https://registry.npmjs.org/@serverless-devs/load-component/-/load-component-0.0.10-beta.7.tgz",
+      "integrity": "sha512-rKwnmycw6On94g02q36JNHAC4VJ3DcDhNj2vjGdSwVQ+20iHWXiHGa5zOYQpvfn9W3+v5HNKpff+4It/xmKmGQ==",
       "dev": true,
       "requires": {
         "@serverless-cd/debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
   "devDependencies": {
     "@serverless-devs/core": "^0.1.67-beta.1",
     "@serverless-devs/credential": "^0.0.10",
-    "@serverless-devs/engine": "^0.1.6-beta.20",
+    "@serverless-devs/engine": "^0.1.6-beta.21",
     "@serverless-devs/load-application": "^0.0.16-beta.3",
-    "@serverless-devs/load-component": "^0.0.10-beta.6",
+    "@serverless-devs/load-component": "^0.0.10-beta.7",
     "@serverless-devs/logger": "^0.0.6",
     "@serverless-devs/parse-spec": "^0.0.30-beta.3",
     "@serverless-devs/registry": "^0.0.12-beta.7",


### PR DESCRIPTION
- Bump @serverless-devs/engine from 0.1.6-beta.20 to 0.1.6-beta.21
- Bump @serverless-devs/load-component from 0.0.10-beta.6 to 0.0.10-beta.7
- Update corresponding package-lock.json and package.json entries accordingly

Change-Id: I9613715db005c3a44e6d819b4a5c3118ffbd8ce7
Co-developed-by: Qoder <noreply@qoder.com>